### PR TITLE
Added AllTests functionality for windows

### DIFF
--- a/src/test/scala/Manifest.scala
+++ b/src/test/scala/Manifest.scala
@@ -57,7 +57,29 @@ class SingleTest extends FlatSpec with Matchers {
 
 class AllTests extends FlatSpec with Matchers {
   it should "just werk" in {
-    val werks = getAllTestNames.map{testname => 
+    val werks = getAllTestNames.map{testname =>
+      say(s"testing $testname")
+      val opts = Manifest.allTestOptions(testname)
+      (testname, TestRunner.run(opts))
+    }
+    if(werks.foldLeft(true)(_ && _._2))
+      say(Console.GREEN + "All tests successful!" + Console.RESET)
+    else {
+      val success = werks.map(x => if(x._2) 1 else 0).sum
+      val total   = werks.size
+      say(s"$success/$total tests successful")
+      werks.foreach{ case(name, success) =>
+        val msg = if(success) Console.GREEN + s"$name successful" + Console.RESET
+        else Console.RED + s"$name failed" + Console.RESET
+        say(msg)
+      }
+    }
+  }
+}
+
+class WindowsAllTests extends FlatSpec with Matchers {
+  it should "just werk" in {
+    val werks = getAllWindowsTestNames.map{testname =>
       say(s"testing $testname")
       val opts = Manifest.allTestOptions(testname)
       (testname, TestRunner.run(opts))

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -59,9 +59,12 @@ object fileUtils {
     new File(getClass.getClassLoader.getResource("tests").getPath)
 
   def getAllTests: List[File] = getListOfFilesRecursive(getTestDir.getPath)
-      .filter( f => f.getPath.endsWith(".s") )
+    .filter( f => f.getPath.endsWith(".s") )
 
   def getAllTestNames: List[String] = getAllTests.map(_.toString.split("/").takeRight(1).mkString)
+
+  def getAllWindowsTestNames: List[String] = getAllTests.map(_.toString.split("\\\\").takeRight(1).mkString)
+
 
   def clearTestResults = {
     try {
@@ -79,7 +82,7 @@ object fileUtils {
   def readTest(testOptions: TestOptions): Either[String, List[String]] = {
 
     // Ahh, the GNU toolchain and its tabs
-    val annoyingTabCharacter = '	' 
+    val annoyingTabCharacter = '	'
 
     getAllTests.filter(_.getName.contains(testOptions.testName)).headOption.toRight(s"File not found: ${testOptions.testName}").flatMap{ filename =>
       import scala.io.Source


### PR DESCRIPTION
Tested and works on Windows 10 using Intellij Idea (2019.2.2). References tests by relative path instead of absolute path.
Testing may be done using "testOnly FiveStage.WindowsAllTest" in sbt terminal.

This should (hopefully, I haven't tested on other computers than my own) make it possible to run the "testonly AllTest"-command on windows without using a subsystem.